### PR TITLE
FCM 토큰 추가

### DIFF
--- a/src/main/java/fresco/com/member/controller/MemberController.java
+++ b/src/main/java/fresco/com/member/controller/MemberController.java
@@ -1,0 +1,33 @@
+package fresco.com.member.controller;
+
+import fresco.com.auth.domain.CustomUserDetails;
+import fresco.com.member.controller.dto.request.FcmTokenRequest;
+import fresco.com.member.domain.Member;
+import fresco.com.member.domain.repository.MemberRepository;
+import fresco.com.member.domain.token.FcmToken;
+import fresco.com.member.domain.token.repository.FcmTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/member")
+@RequiredArgsConstructor
+public class MemberController {
+    private final FcmTokenRepository fcmTokenRepository;
+    private final MemberRepository memberRepository;
+
+    @PostMapping("/fcm-token")
+    public ResponseEntity<Void> registerFcmToken(@RequestBody FcmTokenRequest request) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        Member member = memberRepository.findById(userDetails.getUserId()).orElseThrow();
+
+        if (fcmTokenRepository.findByToken(request.token()).isEmpty()) {
+            fcmTokenRepository.save(FcmToken.of(member, request.token()));
+        }
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/fresco/com/member/controller/dto/request/FcmTokenRequest.java
+++ b/src/main/java/fresco/com/member/controller/dto/request/FcmTokenRequest.java
@@ -1,0 +1,3 @@
+package fresco.com.member.controller.dto.request;
+
+public record FcmTokenRequest(String token) {}

--- a/src/main/java/fresco/com/member/domain/token/FcmToken.java
+++ b/src/main/java/fresco/com/member/domain/token/FcmToken.java
@@ -1,0 +1,33 @@
+package fresco.com.member.domain.token;
+
+import fresco.com.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "fcm_token")
+public class FcmToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    public FcmToken(Member member, String token) {
+        this.member = member;
+        this.token = token;
+    }
+
+    public static FcmToken of(Member member, String token) {
+        return new FcmToken(member, token);
+    }
+}

--- a/src/main/java/fresco/com/member/domain/token/repository/FcmTokenRepository.java
+++ b/src/main/java/fresco/com/member/domain/token/repository/FcmTokenRepository.java
@@ -1,0 +1,12 @@
+package fresco.com.member.domain.token.repository;
+
+import fresco.com.member.domain.token.FcmToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
+    Optional<FcmToken> findByToken(String token);
+}


### PR DESCRIPTION
## Summary
- allow storing FCM tokens for mobile clients
- add endpoint to register an FCM token

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684bca3e916883238a6483775f6beaee