### PR TITLE
[Fix] 레시피 조회 화면에 즐겨찾기 정렬 해제

### DIFF
--- a/src/main/java/com/example/fresco/global/response/success/RefrigeratorSuccessCode.java
+++ b/src/main/java/com/example/fresco/global/response/success/RefrigeratorSuccessCode.java
@@ -11,6 +11,7 @@ public enum RefrigeratorSuccessCode implements SuccessCode {
     REFRIGERATOR_DELETE_SUCCESS("REFRIGERATOR_OK_002", HttpStatus.OK, "냉장고 삭제 성공"),
     REFRIGERATOR_UPDATE_SUCCESS("REFRIGERATOR_OK_003", HttpStatus.OK, "냉장고 정보 변경 성공"),
     REFRIGERATOR_LIST_SUCCESS("REFRIGERATOR_OK_004", HttpStatus.OK, "냉장고 전체 조회 성공"),
+    REFRIGERATOR_PERMISSION_SUCCESS("REFRIGERATOR_OK_005", HttpStatus.OK, "냉장고 편집 권한 조회 성공"),
     ;
 
     private final String code;

--- a/src/main/java/com/example/fresco/recipe/service/RecipeService.java
+++ b/src/main/java/com/example/fresco/recipe/service/RecipeService.java
@@ -115,9 +115,7 @@ public class RecipeService {
         Set<Long> favoriteIds = favoriteRepository.findAllRecipeIdsByUserId(userId);
 
         recipes.sort(
-                Comparator
-                        .comparing((Recipe r) -> !favoriteIds.contains(r.getId())) // false(즐겨찾기) 먼저
-                        .thenComparing(Recipe::getCreatedDate, Comparator.nullsLast(Comparator.reverseOrder()))
+                Comparator.comparing(Recipe::getCreatedDate, Comparator.nullsLast(Comparator.reverseOrder()))
         );
 
         // DTO 변환

--- a/src/main/java/com/example/fresco/refrigerator/controller/RefrigeratorController.java
+++ b/src/main/java/com/example/fresco/refrigerator/controller/RefrigeratorController.java
@@ -12,6 +12,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1/refrigerator")
@@ -49,5 +50,13 @@ public class RefrigeratorController {
     ) {
         return SuccessResponse.of(RefrigeratorSuccessCode.REFRIGERATOR_LIST_SUCCESS,
                 refrigeratorService.getAllRefrigerator(new GetAllRefrigeratorRequest(userId)));
+    }
+
+    @GetMapping("/permissions")
+    public SuccessResponse<Map<Long, Boolean>> getPermissionRefrigerator(
+            @AuthenticationPrincipal Long userId
+    ){
+        return SuccessResponse.of(RefrigeratorSuccessCode.REFRIGERATOR_PERMISSION_SUCCESS,
+                refrigeratorService.getEditableMapByUser(userId));
     }
 }

--- a/src/main/java/com/example/fresco/refrigerator/domain/Refrigerator.java
+++ b/src/main/java/com/example/fresco/refrigerator/domain/Refrigerator.java
@@ -15,10 +15,9 @@ public class Refrigerator extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
+    private Long creator;
 
-    public Refrigerator(String name) {
-        this.name = name;
-    }
+    public Refrigerator(String name, Long creator) { this.name = name;  this.creator = creator; }
 
     public void changeName(String name) {
         this.name = name;

--- a/src/main/java/com/example/fresco/refrigerator/domain/repository/RefrigeratorRepository.java
+++ b/src/main/java/com/example/fresco/refrigerator/domain/repository/RefrigeratorRepository.java
@@ -2,8 +2,18 @@ package com.example.fresco.refrigerator.domain.repository;
 
 import com.example.fresco.refrigerator.domain.Refrigerator;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface RefrigeratorRepository extends JpaRepository<Refrigerator, Long> {
+    @Query("""
+        select r.id
+        from Refrigerator r
+        where r.creator = :userId
+          and r.id in :ids
+    """)
+    List<Long> findIdsByCreatorAndIds(Long userId, List<Long> ids);
 }

--- a/src/main/java/com/example/fresco/refrigerator/domain/repository/RefrigeratorUserRepository.java
+++ b/src/main/java/com/example/fresco/refrigerator/domain/repository/RefrigeratorUserRepository.java
@@ -42,4 +42,12 @@ public interface RefrigeratorUserRepository extends JpaRepository<RefrigeratorUs
                     "where ri.expirationDate between current_date and :daysLater"
     )
     List<Long> findExpiringIngredientsWithinDays(LocalDate daysLater);
+
+    @Query("""
+        select r.id
+        from RefrigeratorUser ru
+            join ru.refrigerator r
+        where ru.user.id = :userId
+    """)
+    List<Long> findRefrigeratorIdsByUserId(Long userId);
 }

--- a/src/main/java/com/example/fresco/refrigerator/service/RefrigeratorService.java
+++ b/src/main/java/com/example/fresco/refrigerator/service/RefrigeratorService.java
@@ -12,6 +12,7 @@ import com.example.fresco.refrigerator.controller.dto.request.refrigerator.Updat
 import com.example.fresco.refrigerator.controller.dto.response.RefrigeratorInfoResponse;
 import com.example.fresco.refrigerator.domain.Refrigerator;
 import com.example.fresco.refrigerator.domain.RefrigeratorUser;
+import com.example.fresco.refrigerator.domain.repository.RefrigeratorInvitationRepository;
 import com.example.fresco.refrigerator.domain.repository.RefrigeratorRepository;
 import com.example.fresco.refrigerator.domain.repository.RefrigeratorUserRepository;
 import com.example.fresco.user.domain.User;
@@ -23,7 +24,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
-import java.util.List;
+import java.util.*;
 
 @Service
 @Validated
@@ -37,7 +38,7 @@ public class RefrigeratorService {
 
     @Transactional
     public RefrigeratorInfoResponse createRefrigerator(@Valid CreateRefrigeratorRequest request) {
-        Refrigerator savedRefrigerator = refrigeratorRepository.save(new Refrigerator(request.name()));
+        Refrigerator savedRefrigerator = refrigeratorRepository.save(new Refrigerator(request.name(), request.userId()));
         GroceryList savedGroceryList = saveGroceryList(savedRefrigerator);
         log.info("userId : {}", request.userId());
         User user = userRepository.findById(request.userId())
@@ -81,5 +82,19 @@ public class RefrigeratorService {
                 .totalAmount(0)
                 .build();
         return groceryListRepository.save(groceryList);
+    }
+
+    @Transactional(readOnly = true)
+    public Map<Long, Boolean> getEditableMapByUser(Long userId) {
+        List<Long> refrigeratorIds = refrigeratorUserRepository.findRefrigeratorIdsByUserId(userId);
+        List<Long> ownedIds = refrigeratorRepository.findIdsByCreatorAndIds(userId, refrigeratorIds);
+
+        Set<Long> editableIds = new HashSet<>(ownedIds);
+
+        Map<Long, Boolean> result = new LinkedHashMap<>();
+        for (Long id : refrigeratorIds) {
+            result.put(id, editableIds.contains(id));
+        }
+        return result;
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #63 #65 

## 📝 작업 내용

- 레시피 조회 시 즐겨찾기 정렬 해제
- 냉장고 수정 권한 조회 api 추가